### PR TITLE
bump  Tiny Core Linux to v14

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ trap cleanup EXIT
 # Default config for 64-bit Linux and Sedutil
 GRUBSIZE=15 # Reserve this amount of MiB on the image for GRUB (increase this number if needed)
 CACHEDIR="cache"
-TCURL="http://distro.ibiblio.org/tinycorelinux/13.x/x86_64"
+TCURL="http://distro.ibiblio.org/tinycorelinux/14.x/x86_64"
 EXTENSIONS="bash.tcz"
 INPUTISO="TinyCorePure64-current.iso"
 OUTPUTIMG="sedunlocksrv-pba.img"

--- a/tc/tc-config
+++ b/tc/tc-config
@@ -12,7 +12,6 @@ GREEN="$(echo -e '\033[1;32m')"
 MAGENTA="$(echo -e '\033[1;35m')"
 NORMAL="$(echo -e '\033[0;39m')"
 
-. /etc/init.d/busybox-aliases
 export PATH=/usr/local/sbin:/usr/local/bin:"$PATH"
 
 # Start Udev to populate /dev and handle hotplug events


### PR DESCRIPTION
I have tested both build and SED go program functionality. All works as before.

busybox has been  updated to 1.36.0 and busybox-aliases are gone - modified tc-config to reflect it.

Now can move to serious stuff:)