### PR TITLE
fix build on Ubuntu 22.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ After running the command above you will find sedunlocksrv-pba.img in your curre
 - Update with: `apt-get update && apt-get -y upgrade`
 - Continue with building in the next steps
 
-## Building on Ubuntu 20.04.2
+## Building on Ubuntu 20.04 LTS or Ubuntu 22.04 LTS
 - Install the Go compiler with: `snap install go --classic`
 - Install build dependencies: `apt-get -y install curl libarchive-tools grub-pc-bin grub-efi-ia32-bin grub-efi-amd64-bin xorriso wget git cpio rsync squashfs-tools udev dosfstools fdisk grub2-common`
 - [Download](https://github.com/Jip-Hop/sedunlocksrv-pba/archive/refs/heads/main.zip) or clone this repo and run: `./build.sh`

--- a/build.sh
+++ b/build.sh
@@ -138,7 +138,7 @@ LOOP_DEVICE_HDD=$(losetup --find --show --partscan ${OUTPUTIMG})
     echo     # default - start at beginning of disk
     echo     # default, extend partition to end of disk
     echo t   # change partition type
-    echo e f # set partition type to EFI (FAT-12/16/32)
+    echo ef  # set partition type to EFI (FAT-12/16/32)
     echo a   # make a partition bootable
     echo w   # write the partition table
     echo q   # and we're done


### PR DESCRIPTION
I now build on Ubuntu 22.04 LTS and for some reason fdisk does not like partition type "e f" - it has to be "ef"

On Ubuntu 20.04 LTS both options work.

Hence better to change it to "ef" - more future proof.