### PR TITLE
Remove the `--chmod` option from `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM --platform=amd64 ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update && \
-apt install -y cpio curl dosfstools dropbear fdisk git golang-go grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin grub2-common libarchive-tools rsync squashfs-tools udev wget xorriso
+  apt install -y cpio curl dosfstools dropbear fdisk git golang-go grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin grub2-common libarchive-tools rsync squashfs-tools udev wget xorriso
 
 WORKDIR /tmp
-COPY --chmod=755 . .
+COPY . .
 
 CMD ./build.sh


### PR DESCRIPTION
When building the docker image I got:

```
Step 5/6 : COPY --chmod=755 . .
the --chmod option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
Error response from daemon: No such container: sedunlocksrv-pba
```

I removed `--chmod=755` from the copy operation and everything worked fine. Can it be removed?