### PR TITLE
bump Tiny Core version to v15.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ trap cleanup EXIT
 # Default config for 64-bit Linux and Sedutil
 GRUBSIZE=15 # Reserve this amount of MiB on the image for GRUB (increase this number if needed)
 CACHEDIR="cache"
-TCURL="http://distro.ibiblio.org/tinycorelinux/14.x/x86_64"
+TCURL="http://distro.ibiblio.org/tinycorelinux/15.x/x86_64"
 INPUTISO="TinyCorePure64-current.iso"
 OUTPUTIMG="sedunlocksrv-pba.img"
 BOOTARGS="quiet libata.allow_tpm=1"


### PR DESCRIPTION
[Tiny Core v15.0](https://forum.tinycorelinux.net/index.php/topic,26861.0.html) updates the linux kernel version to 6.6.8 glibc updated to 2.38, gcc updated to 13.2.0

Building with various options and functionality has been tested. All works out of the box without any additional tweaks needed.