### PR TITLE
Update build.sh to resolve SSH permission issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -142,6 +142,9 @@ if [ $SSHBUILD == "TRUE" ]; then
     mkdir -p "${TMPDIR}/core/home/tc/.ssh"
     cp ./ssh/authorized_keys "${TMPDIR}/core/home/tc/.ssh/"
     cp ./ssh/ssh_sed_unlock.sh "${TMPDIR}/core/home/tc/"
+    chown -R 1001 "${TMPDIR}/core/home/tc/"
+    chmod 700 "${TMPDIR}/core/home/tc/.ssh"
+    chmod 600 "${TMPDIR}/core/home/tc/.ssh/authorized_keys"
 fi
 
 # Since we installed the scsi extension by extracting it rather than using tce-load, we need to fix modules.dep


### PR DESCRIPTION
Make changes to build.sh to correct permissions that could affect using SSH to access and unlock the disk.