### PR TITLE
Error data queue siser is too large with unsquashfs use mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM --platform=amd64 ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PARTID=05ED-05ED
 
 RUN apt update && \
   apt install -y cpio curl dosfstools dropbear fdisk git golang-go grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin grub2-common libarchive-tools rsync squashfs-tools udev wget xorriso
@@ -8,4 +9,4 @@ RUN apt update && \
 WORKDIR /tmp
 COPY . .
 
-CMD ./build.sh
+CMD ./build.sh SSH

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Even for systems which support encrypting all drives, using a SED with `sedunloc
 - Not limited to us_english keyboard mapping
 - Reboot button to boot from the unlocked drive
 - BIOS and UEFI support
+- Possible Add Entry on UEFI if remove when boot on sedunlocksrv-pba with sed status mbrdone is false ( work only on ssh and console no https)
 
 ## SED benefits
 - Encrypt your (boot) drive, even when the OS doesn't (fully) support encryption
@@ -85,6 +86,13 @@ Optionally you can use other `sedutil` forks of the [official Drive-Trust-Allian
 - `ChubbyAnt`: [Fork by ChubbyAnt](https://github.com/ChubbyAnt/sedutil)
 
 Example: `sudo SEDUTIL_FORK="ChubbyAnt" ./build.sh`
+
+
+## Optional Add Entry on UEFI 
+
+USE ENV Variable PARTID for defined partion id of partion EFI ( PARTID="05ED-05ED" )
+Use Ctrl-E For add entry on EFI need path /EFI/Label/*.efi
+
 
 ## Optional SED unlock via SSH
 

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,11 @@ EXTENSIONS="bash.tcz"
 if [ $SSHBUILD == "TRUE" ]; then
     EXTENSIONS="$EXTENSIONS dropbear.tcz"
 fi
+if [ ! -z ${PARTID} ] ;then
+  echo "Add entry EFI configured"
+  EXTENSIONS="$EXTENSIONS efibootmgr.tcz"
+  BOOTARGS="$BOOTARGS efi=runtime"
+fi
 case "$(echo ${SEDUTIL_FORK-} | tr '[:upper:]' '[:lower:]')" in
     "chubbyant")
         SEDUTIL_FORK="ChubbyAnt"
@@ -131,6 +136,11 @@ while [ -n "${EXTENSIONS}" ]; do
     EXTENSIONS="${DEPS}"
 done
 
+if [ ! -z ${PARTID} ] ;then
+  mkdir -p "${TMPDIR}/core/home/tc/"
+  echo -en  ${PARTID} > "${TMPDIR}/core/home/tc/partid-efi"
+fi    
+
 if [ $SSHBUILD == "TRUE" ]; then
     # Generate dropbear hostkeys if not existing
     if [[ ! -f ./ssh/dropbear_ecdsa_host_key || ! -f ./ssh/dropbear_rsa_host_key ]]; then
@@ -198,6 +208,7 @@ mkfs.fat -F32 "${LOOP_DEVICE_HDD}p1"
 mount "${LOOP_DEVICE_HDD}p1" "${TMPDIR}/img"
 
 # Install GRUB
+
 
 grub-install --no-floppy --boot-directory="${TMPDIR}/img/boot" --target=i386-pc "${LOOP_DEVICE_HDD}"
 grub-install --removable --boot-directory="${TMPDIR}/img/boot" --target=x86_64-efi --efi-directory="${TMPDIR}/img/" "${LOOP_DEVICE_HDD}"

--- a/build.sh
+++ b/build.sh
@@ -118,9 +118,14 @@ sed -i "s/::exclude_devices::/${EXCLUDE_NETDEV-}/" "${TMPDIR}/core/etc/init.d/tc
 while [ -n "${EXTENSIONS}" ]; do
     DEPS=""
     for EXTENSION in ${EXTENSIONS}; do
+        MOUNTDIREXT="$(mktemp -d --tmpdir="$(pwd)" 'mnt.XXXXXX')"
         cachetcfile "${EXTENSION}" tcz tcz
         cachetcfile "${EXTENSION}.dep" dep tcz
-        unsquashfs -f -d "${TMPDIR}/core" "${CACHEDIR}/tcz/${EXTENSION}"
+        mount -o loop "${CACHEDIR}/tcz/${EXTENSION}" "${MOUNTDIREXT}"
+        cp -r "${MOUNTDIREXT}/"* "${TMPDIR}/core/"
+        umount "${MOUNTDIREXT}"
+        rm -rfv "${MOUNTDIREXT}"
+        #unsquashfs -f -d "${TMPDIR}/core" "${CACHEDIR}/tcz/${EXTENSION}"
         DEPS=$(echo "${DEPS}" | cat - "${CACHEDIR}/dep/${EXTENSION}.dep" | sort -u)
     done
     EXTENSIONS="${DEPS}"

--- a/sedunlocksrv/efiupdate.sh
+++ b/sedunlocksrv/efiupdate.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+shopt -s nullglob extglob
+PARTID=$(cat /home/tc/partid-efi 2> /dev/null)
+
+if [ -z ${PARTID} ] ; then
+   echo "Need PartionID defined on ~tc/partid-efi for add EFI entry"
+   exit 1
+fi
+
+# Search partion EFI
+efi_partition=$(sudo blkid  |  grep -i "${PARTID}" | awk '{print $1}' | sed 's/://g')
+
+# Check if partion is detected
+if [ -z "$efi_partition" ]; then
+    echo "Partition EFI with ID ${PARTID} not found."
+    exit 1
+fi
+
+# Extract DEV DISK
+efi_disk="$(echo $efi_partition | sed 's/p[0-9]*$//')"
+
+
+# Extract PART NUMBER
+efi_part_num=$(echo $efi_partition | grep -o '[0-9]*$')
+
+
+# Get information entry EFI
+sudo mount ${efi_partition} /mnt
+loaderefi=$(sudo find /mnt/EFI -type f -name '*.efi' -print | sed 's!/mnt!!g')
+labelefi=$(dirname ${loaderefi} | sed 's!^/EFI/!!g')
+loaderefi=$(echo   ${loaderefi} | sed 's!/!\\!g')
+echo "Disk:${efi_disk} Part:${efi_part_num} Label:${labelefi} Loader:${loaderefi}"
+sudo umount /mnt
+
+# Mount variable EFI
+sudo mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+
+# Add Entry EFI
+sudo efibootmgr --create --disk "$efi_disk" --part "$efi_part_num" --label "$labelefi" --loader "${loaderefi}"
+
+# Prevent reboot without sync
+sync
+sleep 2

--- a/ssh/ssh_sed_unlock.sh
+++ b/ssh/ssh_sed_unlock.sh
@@ -18,8 +18,20 @@ shutdown_function () {
     poweroff -nf
 }
 
+efiupdate_function () {
+    # efiupdate
+    echo
+    /usr/local/sbin/sedunlocksrv/efiupdate.sh
+    echo
+}
+
+
 echo "Press ESC anytime to reboot."
 echo "Press CTRL-D anytime to shutdown."
+if [ -e /home/tc/partid-efi ]; then
+    echo "Press CTRL-E anytime for add entry EFI."
+fi
+
 echo
 
 if /usr/local/sbin/sedunlocksrv/opal-functions.sh | grep -q "Could not detect TCG Opal 2-compliant disks"
@@ -42,6 +54,12 @@ while [ true ] ; do
             reboot_function
             ;;
         $'\0') # if input == ENTER key
+            break
+            ;;
+        $'\005') # if input == CTRL-E key
+            if [ -e /home/tc/partid-efi ]; then
+                efiupdate_function
+            fi
             break
             ;;
         $'\177') # if input == BACKSPACE key


### PR DESCRIPTION
When docker execute build.sh 

```
+ touch cache/dep/bash.tcz.dep
+ unsquashfs -f -d /tmp/img.grHVZL/core cache/tcz/bash.tcz
FATAL ERROR: Data queue size is too large
```


I have replace unsquashfs by mount and cp
```
++ mktemp -d --tmpdir=/tmp mnt.XXXXXX
+ MOUNTDIREXT=/tmp/mnt.GVEVqs

+ mount -o loop cache/tcz/bash.tcz /tmp/mnt.GVEVqs
+ cp -r /tmp/mnt.GVEVqs/usr /tmp/img.xAjeYa/core/
+ umount /tmp/mnt.GVEVqs
+ rm -rfv /tmp/mnt.GVEVqs
removed directory '/tmp/mnt.GVEVqs'
```