### PR TITLE
bump Tiny Core version to v16.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ trap cleanup EXIT
 # Default config for 64-bit Linux and Sedutil
 GRUBSIZE=15 # Reserve this amount of MiB on the image for GRUB (increase this number if needed)
 CACHEDIR="cache"
-TCURL="http://distro.ibiblio.org/tinycorelinux/15.x/x86_64"
+TCURL="http://distro.ibiblio.org/tinycorelinux/16.x/x86_64"
 INPUTISO="TinyCorePure64-current.iso"
 OUTPUTIMG="sedunlocksrv-pba.img"
 BOOTARGS="quiet libata.allow_tpm=1"


### PR DESCRIPTION
[Tiny Core v16.0 ](https://forum.tinycorelinux.net/index.php/topic,27578.0.html)updates the linux kernel version to 6.12.11 glibc to 2.40, gcc to 14.2.0

All tested and used for some time now. Works out of the box without any additional tweaks needed.